### PR TITLE
fix: service endpoint env var not passed to the agent

### DIFF
--- a/agent/docker-compose.yml
+++ b/agent/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       AGENT_DB_NAME: agent
       AGENT_DB_USER: postgres
       AGENT_DB_PASSWORD: postgres
-      DIDCOMM_SERVICE_URL: http://host.docker.internal:${PORT}/didcomm
+      DIDCOMM_SERVICE_URL: ${DIDCOMM_SERVICE_ENDPOINT}
       PRISM_NODE_HOST: prism-node
       PRISM_NODE_PORT: 50053
     depends_on:


### PR DESCRIPTION
Fixed bug in docker-compose, where `DIDCOMM_SERVICE_ENDPOINT` env variable was not passed correctly to the agent runnable, making it unreachable for DIDComm communication.